### PR TITLE
Support for enable/disable of built-in nginx ingress

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource "rke_cluster" "pke" {
     }
   }
   ingress {
-    provider        = "nginx"
+    provider        = var.ingress_default == true ? "nginx" : "none"
     http_port       = 80
     https_port      = 443
     network_mode    = "hostNetwork"

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,3 +25,7 @@ output "client_cert" {
   value = rke_cluster.pke.client_cert
   sensitive = true
 }
+output "admin_user" {
+  value = rke_cluster.pke.kube_admin_user
+  sensitive = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -30,3 +30,9 @@ variable "worker_tags" {
   type        = map(any)
   default     = { default = "default" }
 }
+
+variable "ingress_default" {
+  description = "Set to true in case you want default nginx, or false if you plan to install custom one"
+  type = bool
+  default = true
+}


### PR DESCRIPTION
Changes:
 - new output variable `admin_user` for k8s username
 - new variable `ingress_default` for installing or not default ingress