### PR TITLE
add option to specify number of CPUs used by ingress

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,7 @@ resource "rke_cluster" "pke" {
       use-gzip                  = var.use_compression == true ? true : false
       enable-brotli             = var.use_compression == true ? true : false
       allow-snippet-annotations = true
-      var.ingress_ncpu          = var.ingress_ncpu == "auto" ? "auto" : var.ingress_ncpu
+      ingress_ncpu              = var.ingress_ncpu == "auto" ? "auto" : var.ingress_ncpu
     }
     node_selector = {
       do_ingress = "please"

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
     # https://github.com/rancher/terraform-provider-rke/releases
     rke = {
       source  = "rancher/rke"
-      version = "1.4.4"
+      version = "1.5.0"
     }
     # https://github.com/hashicorp/terraform-provider-kubernetes/releases
     kubernetes = {

--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,7 @@ resource "rke_cluster" "pke" {
       use-gzip                  = var.use_compression == true ? true : false
       enable-brotli             = var.use_compression == true ? true : false
       allow-snippet-annotations = true
-      var.ingress_ncpu == "auto" ? "auto" : var.ingress_ncpu
+      var.ingress_ncpu          = var.ingress_ncpu == "auto" ? "auto" : var.ingress_ncpu
     }
     node_selector = {
       do_ingress = "please"

--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,7 @@ resource "rke_cluster" "pke" {
       use-gzip                  = var.use_compression == true ? true : false
       enable-brotli             = var.use_compression == true ? true : false
       allow-snippet-annotations = true
+      var.ingress_ncpu == "auto" ? "auto" : var.ingress_ncpu
     }
     node_selector = {
       do_ingress = "please"

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,11 @@ variable "use_compression" {
   type        = bool
   default     = false
 }
+variable "ingress_ncpu" {
+  description = "Set to desired number of CPUs to be used by nginx ingress controller"
+  type        = "string"
+  default     = "auto"
+}
 
 variable "image_puller" {
   description = "Name of image puller secret used for pulling"

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,7 @@ variable "use_compression" {
 }
 variable "ingress_ncpu" {
   description = "Set to desired number of CPUs to be used by nginx ingress controller"
-  type        = "string"
+  type        = string
   default     = "auto"
 }
 


### PR DESCRIPTION
Changes:
- bumped upstream version to `1.5.0`
- added new variable `ingress_ncpu` that sets number of processes on nginx ingres (if not used it sets `auto`)
